### PR TITLE
Add PKCS#11 URI support for private key

### DIFF
--- a/modules/ssl/ssl_engine_init.c
+++ b/modules/ssl/ssl_engine_init.c
@@ -1268,19 +1268,32 @@ static apr_status_t ssl_init_server_certs(server_rec *s,
 
             ERR_clear_error();
 
-            /* perhaps it's an encrypted private key, so try again */
-            ssl_load_encrypted_pkey(s, ptemp, i, keyfile, &pphrases);
+#if defined(HAVE_OPENSSL_ENGINE_H) && defined(HAVE_ENGINE_INIT)
+            /*
+             * Try to load the key using an engine. If if fails, treat as a file.
+             */
+            ssl_engine_load_pkey(s, ptemp, i, keyfile, &pkey);
+            if (SSL_CTX_use_PrivateKey(mctx->ssl_ctx, pkey) < 1) {
+                ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, s, APLOGNO()
+                        "Failed to configure key %s using engine. Now trying to"
+                        " open %s", key_id, keyfile);
+#endif
+                /* perhaps it's an encrypted private key, so try again */
+                ssl_load_encrypted_pkey(s, ptemp, i, keyfile, &pphrases);
 
-            if (!(asn1 = ssl_asn1_table_get(mc->tPrivateKey, key_id)) ||
-                !(ptr = asn1->cpData) ||
-                !(pkey = d2i_AutoPrivateKey(NULL, &ptr, asn1->nData)) ||
-                (SSL_CTX_use_PrivateKey(mctx->ssl_ctx, pkey) < 1)) {
-                ap_log_error(APLOG_MARK, APLOG_EMERG, 0, s, APLOGNO(02564)
-                             "Failed to configure encrypted (?) private key %s,"
-                             " check %s", key_id, keyfile);
-                ssl_log_ssl_error(SSLLOG_MARK, APLOG_EMERG, s);
-                return APR_EGENERAL;
+                if (!(asn1 = ssl_asn1_table_get(mc->tPrivateKey, key_id)) ||
+                    !(ptr = asn1->cpData) ||
+                    !(pkey = d2i_AutoPrivateKey(NULL, &ptr, asn1->nData)) ||
+                    (SSL_CTX_use_PrivateKey(mctx->ssl_ctx, pkey) < 1)) {
+                    ap_log_error(APLOG_MARK, APLOG_EMERG, 0, s, APLOGNO(02564)
+                                 "Failed to configure encrypted (?) private key %s,"
+                                 " check %s", key_id, keyfile);
+                    ssl_log_ssl_error(SSLLOG_MARK, APLOG_EMERG, s);
+                    return APR_EGENERAL;
+                }
+#if defined(HAVE_OPENSSL_ENGINE_H) && defined(HAVE_ENGINE_INIT)
             }
+#endif
         }
 
         if (SSL_CTX_check_private_key(mctx->ssl_ctx) < 1) {

--- a/modules/ssl/ssl_private.h
+++ b/modules/ssl/ssl_private.h
@@ -979,6 +979,11 @@ BOOL         ssl_util_vhost_matches(const char *servername, server_rec *s);
 /**  Pass Phrase Support  */
 apr_status_t ssl_load_encrypted_pkey(server_rec *, apr_pool_t *, int,
                                      const char *, apr_array_header_t **);
+#if defined(HAVE_OPENSSL_ENGINE_H) && defined(HAVE_ENGINE_INIT)
+apr_status_t ssl_engine_load_pkey(server_rec *s, apr_pool_t *p, int idx,
+                                  const char *pkey_file,
+				                  EVP_PKEY **ppkey);
+#endif
 
 /**  Diffie-Hellman Parameter Support  */
 DH           *ssl_dh_GetParamFromFile(const char *);


### PR DESCRIPTION
Enable the use of PKCS#11 URIs in the mod_ssl configuration files, allowing the use of keys stored in PKCS#11 devices.
Only the SSLCertificateKeyFile directive is modified.

To use a PKCS#11 device, the following directives have to be configured in the configuration files:
```
# To use the libp11 OpenSSL engine (the engine is responsible for processing the PKCS#11 URI)
SSLCryptoDevice pkcs11

# Use a PKCS#11 URI to point to the key to be used. e.g.:
SSLCertificateKeyFile pkcs11:token=apache-test;object=pkey;type=private

# Point to a certificate for the used key. e.g.:
SSLCertificateFile /tmp/localhost.crt
```

Summary of changes:

* ssl_engine_config.c
  * Modified the SSLCertificateKeyFile directive validation to accept PKCS#11 URIs
* ssl_engine_init.c
  * Modify ssl_init_server_certs() in ssl_engine_init.c to make it try to load using a engine, if available
* ssl_engine_pphrase.c
  * Added ssl_engine_load_pkey() to call ENGINE_load_private_key()